### PR TITLE
cpprefjp のツリーの最後の子要素の縦罫線を上半分だけに修正

### DIFF
--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -119,7 +119,7 @@
   border:1px solid #faa937;
   color:#000
 }
-.tree li:last-child::before{height:30px}
+.tree li:last-child::before{height:13px}
 .tree>ul>li::before,.tree>ul>li::after{border:0}
 .google-search {
     width: 250px;


### PR DESCRIPTION
ツリーの最後の子要素の縦罫線が次の要素の「＋」や「－」記号にくっついていたので、最後の子要素だけ縦罫線を上半分だけにしてみましたが、いかがでしょうか。