### PR TITLE
ツリーの並び順をパス名からタイトルに変更

### DIFF
--- a/run.py
+++ b/run.py
@@ -154,7 +154,7 @@ class Sidebar(object):
 
     @property
     def children(self):
-        return sorted(self._children.values(), key=lambda x: (x.is_node, x.name))
+        return sorted(self._children.values(), key=lambda x: (x.is_node, x.title))
 
     def set_pageinfo(self, paths, href, title, *args, **kwargs):
         sidebar = self


### PR DESCRIPTION
ツリーを見るとこちらの方が自然だと思うのですが、いかがでしょうか。