### PR TITLE
MathJax のディスプレイ数式を左寄せに変更

### DIFF
--- a/cpprefjp/templates/content.html
+++ b/cpprefjp/templates/content.html
@@ -108,7 +108,8 @@
           displayMath: [ ['$$','$$'] ],
           processEscapes: true
         },
-        "HTML-CSS": { availableFonts: ["TeX"] }
+        "HTML-CSS": { availableFonts: ["TeX"] },
+        displayAlign: "left"
       });
     </script>
     <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js"></script>


### PR DESCRIPTION
今までの数式は基本左寄せで表示されていたと思うので、MathJax のディスプレイ数式も左寄せに変更してみましたが、いかがでしょうか？