### PR TITLE
隣り合った code を結合するようにした

### DIFF
--- a/run.py
+++ b/run.py
@@ -35,6 +35,10 @@ def make_html_path(path):
     return os.path.join(settings.OUTPUT_DIR, path + '.html')
 
 
+_SWAP_A_AND_CODE_RE = re.compile(r'<(a|span)\b([^>]*)><code>([^<]*)</code>(</\1>)')
+_MERGE_ADJACENT_CODE_RE = re.compile(r'</code>( ?)<code>')
+
+
 def md_to_html(md_data, path, hrefs=None):
     paths = path.split('/')
 
@@ -61,6 +65,8 @@ def md_to_html(md_data, path, hrefs=None):
     md._html_attribute_hrefs = hrefs
 
     html = md.convert(md_data)
+    html = _SWAP_A_AND_CODE_RE.sub(r'<code><\1\2>\3</\1></code>', html)
+    html = _MERGE_ADJACENT_CODE_RE.sub(r'\1', html)
     return html, {
         'meta_result': md._meta_result,
         'mathjax_enabled': md._mathjax_enabled


### PR DESCRIPTION
文中の `code` の一部をリンクにしたい場合、コードを分割する必要がありますが、そうすると html では `code` 要素が分割されてしまい妙に間が空いて間が抜けて見えてしまいます。

そこで、隣り合った `code` 要素を結合するようにしてみました。

ただし、markdown の書き方の問題でそれだけではうまくいかないので、まず最初に、

`<a href="..."><code>...</code></a>`

を

`<code><a href="...">...</a></code>`

に変換してから結合するようにしています。

また、`code` 要素の間は空白 1 文字まで許容しています。

ちゃんと html を解釈した方が良いとは思うのですが、ちょっと横着をして、単なる正規表現で処理しちゃってます。

現時点で cpprefjp では変換エラーは発生しませんでした。
全ページ目視確認したわけでは無いのですが、何ページかサンプルで見た感じではうまく変換できているようでした。

いかがでしょうか？