### PR TITLE
MathJax のリンク先を変更した。

### DIFF
--- a/cpprefjp/templates/content.html
+++ b/cpprefjp/templates/content.html
@@ -114,6 +114,6 @@
         displayAlign: "left",
       });
     </script>
-    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
cdn.mathjax.org が　2017/4/30 でシャットダウンされるため、MathJax
のリンク先を cdnjs に変更した。

https://www.mathjax.org/cdn-shutting-down/