### PR TITLE
classの名前は`::`でsplitする

### DIFF
--- a/crsearch.json/run.py
+++ b/crsearch.json/run.py
@@ -39,7 +39,7 @@ class Validator(object):
                             'minItems': 1,
                             'items': {
                                 'type': 'string',
-                                'pattern': '[^/]+',
+                                'pattern': '^[^/]+$',
                             },
                         },
                         'path_prefixes': {
@@ -47,7 +47,7 @@ class Validator(object):
                             'minItems': 1,
                             'items': {
                                 'type': 'string',
-                                'pattern': '[^/]+',
+                                'pattern': '^[^/]+$',
                             },
                         },
                         'cpp_version': {
@@ -69,7 +69,7 @@ class Validator(object):
                                         'minItems': 1,
                                         'items': {
                                             'type': 'string',
-                                            'pattern': '[^/]+',
+                                            'pattern': '^[^/]+$',
                                         },
                                     },
                                     'related_to': {
@@ -114,14 +114,14 @@ class Validator(object):
                         'type': 'array',
                         'items': {
                             'type': 'string',
-                            'pattern': '[^"<>]+',
+                            'pattern': '^[^"<>]+$',
                         },
                     },
                     'cpp_namespace': {
                         'type': 'array',
                         'items': {
                             'type': 'string',
-                            'pattern': '[^:]+',
+                            'pattern': '^[^:]+$',
                         },
                     },
                 },
@@ -138,14 +138,14 @@ class Validator(object):
                         'type': 'array',
                         'items': {
                             'type': 'string',
-                            'pattern': '[^:]+',
+                            'pattern': '^[^:]+$',
                         },
                     },
                     'cpp_namespace': {
                         'type': 'array',
                         'items': {
                             'type': 'string',
-                            'pattern': '[^:]+',
+                            'pattern': '^[^:]+$',
                         },
                     },
                 },
@@ -237,11 +237,14 @@ class Generator(object):
         for line in lines:
             m = self._META_RE.match(line)
             if m is not None:
-                target = m.group('target')
                 name = m.group('name')
                 if name not in result:
                     result[name] = []
-                result[name].append(target)
+                if name == 'class':
+                    result[name] += m.group('target').split('::')
+                else:
+                    result[name].append(m.group('target'))
+
         return result
 
     def make_index(self, md, names, idgen, nojump):

--- a/crsearch.json/test.py
+++ b/crsearch.json/test.py
@@ -48,6 +48,7 @@ class TestRun(unittest.TestCase):
             'test/reference/vector.md',
             'test/reference/vector/push_back.md',
             'test/reference/vector/swap_free.md',
+            'test/reference/ios/ios_base/failure/op_constructor.md',
         ]
         value = run.Generator().generate('test', paths, paths)
         run.Validator().validate(value)

--- a/crsearch.json/test/reference/ios/ios_base/failure/op_constructor.md
+++ b/crsearch.json/test/reference/ios/ios_base/failure/op_constructor.md
@@ -1,0 +1,99 @@
+# コンストラクタ
+* ios[meta header]
+* function[meta id-type]
+* std[meta namespace]
+* ios_base::failure[meta class]
+
+```cpp
+explicit failure(const string& msg);                                            // (1) C++03 まで
+
+explicit failure(const string& msg, const error_code& ec = io_errc::stream);    // (2) C++11 から
+
+explicit failure(const char* msg, const error_code& ec = io_errc::stream);      // (3) C++11 から
+```
+* string[link ../../../string/basic_string.md]
+* error_code[link ../../../system_error/error_code.md]
+* io_errc[link ../../io_errc.md]
+
+## 概要
+[`ios_base`](../../ios_base.md)`::`[`failure`](../failure.md) オブジェクトを構築する。
+
+
+## 効果
+- (1) [`strcmp`](../../../cstring/strcmp.md.nolink)`(`[`what`](what.md)`(), msg.`[`c_str`](../../../string/basic_string/c_str.md)`()) == 0` となる [`ios_base`](../../ios_base.md)`::`[`failure`](../failure.md) オブジェクトを構築する。
+- (2)、(3) 引数 `msg` と `ec` を用いて基底クラスを構築して、[`ios_base`](../../ios_base.md)`::`[`failure`](../failure.md) オブジェクトを構築する。
+
+
+## 例
+### C++03 までの例
+```cpp
+#include <iostream>
+
+int main()
+{
+  std::ios_base::failure f("error message");
+  std::cout << f.what() << std::endl;
+}
+```
+* failure[link ../failure.md]
+* std::ios_base[link ../../ios_base.md]
+* what()[link what.md]
+
+### 出力
+```
+error message
+```
+
+
+### C++11 からの例
+```cpp
+#include <iostream>
+#include <system_error>
+
+int main()
+{
+  std::ios_base::failure f1("error message");
+  std::cout << f1.what() << std::endl;
+  std::ios_base::failure f2("error message", std::make_error_code(std::errc::no_such_file_or_directory));
+  std::cout << f2.what() << std::endl;
+}
+```
+* iostream[link ../../../iostream.md]
+* system_error[link ../../../system_error.md]
+* failure[link ../failure.md]
+* make_error_code[link ../../../system_error/make_error_code.md]
+* errc[link ../../../system_error/errc.md]
+* cout[link ../../../iostream/cout.md]
+* endl[link ../../../ostream/endl.md]
+* ios_base[link ../../ios_base.md]
+* what[color ff0000]
+
+### 出力例
+```
+error message: unspecified iostream_category error
+error message: No such file or directory
+```
+
+
+## バージョン
+## 言語
+- C++98
+
+### 処理系
+- [Clang](/implementation.md#clang): 3.0, 3.1, 3.2, 3.3, 3.4, 3.5.0, 3.6.0, 3.7.0, 3.8.0
+- [GCC](/implementation.md#gcc): 4.3.6, 4.4.7, 4.5.4, 4.6.4, 4.7.3, 4.8.1, 4.8.2, 4.9.0, 4.9.1, 4.9.2, 5.1.0, 5.2.0, 6.0.0
+- [GCC, C++11 mode](/implementation.md#gcc): 5.1.0, 5.2.0, 6.0.0
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+
+### 備考
+- GCC 5.1.0 以降では、単に C++03 モードにしても [`strcmp`](../../../cstring/strcmp.md.nolink)`(`[`what`](what.md)`(), msg.`[`c_str`](../../../string/basic_string/c_str.md)`()) == 0` にはならない。  
+    マクロ `_GLIBCXX_USE_CXX11_ABI` を `0`に設定すれば完全に C++03 の挙動になる。  
+    [クラスページ](../failure.md)のバージョン欄の備考も参照。
+- Clang では、C++03 モードでも [`strcmp`](../../../cstring/strcmp.md.nolink)`(`[`what`](what.md)`(), msg.`[`c_str`](../../../string/basic_string/c_str.md)`()) == 0` にはならない。  
+
+
+## 参照
+- [`what`](what.md)
+- [`exception`](../../../exception/exception.md)
+- [`system_error`](../../../system_error/system_error.md)


### PR DESCRIPTION
以下はコミットメッセージからコピペ

In JSON Schema RFC $6.8:

> Recall: regular expressions are not implicitly anchored.

http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.8

...and our Python library 'jsonschema' was pretty good at following this spec.

All our tests were not following this spec, thus none of regex-based tests were valid at all. This error led to mis-interpretion in IndexID::key for nested members (e.g. `ios_base::failure::what` as below:

Expected: `['ios_base', 'failure', 'what']`
Actual:   `['ios_base::failure', 'what']`