### PR TITLE
Fix `./docker.sh build` missing for boostjp

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ http://localhost:8000 を開けば `index.html` が表示されます。
 
 ```bash
 git clone https://github.com/boostjp/site.git boostjp/site
+
+# site_generator 用の docker イメージを生成する
+./docker.sh build
 ```
 
 実行:


### PR DESCRIPTION
#56 に関連して、boostjpの生成にも同dockerは必要だったので追加しました。

#45 #46 が Resolve されたらまた変更が必要そうですね。