### PR TITLE
サイドバーや検索がローカルで正しく動作しない問題を修正

### DIFF
--- a/crsearch.json/run.py
+++ b/crsearch.json/run.py
@@ -419,7 +419,7 @@ class Generator(object):
         namespaces = sorted(namespaces.values(), key=lambda ns: ns['namespace'])
 
         result = {
-            'base_url': 'https://cpprefjp.github.io',
+            'base_url': '/',
             'database_name': 'cpprefjp',
             'namespaces': namespaces,
             'ids': idgen.get_all(),


### PR DESCRIPTION
ローカルで動作させた時に、生成された crsearch.json の base_url が
https://cpprefjp.github.io になっているためサイドバーのリンクや検索が
cpprefjp.github.io に向いてしまっていたので、正しくローカル側指すよう
に修正した。

なお、サイドバーや検索をローカルで正しく動作させるためには、本修正の他に
crsearch と kunai の修正も必要。