### PR TITLE
#67 op_compare_3way を並び替えルールに追加

### DIFF
--- a/settings/cpprefjp.py
+++ b/settings/cpprefjp.py
@@ -115,6 +115,7 @@ ORDER_PRIORITY_LIST = [
     'op_less_equal',  # operator<=(a, b)
     'op_greater',  # operator>(a, b)
     'op_greater_equal',  # operator>=(a, b)
+    'op_compare_3way', # operator<=>(a, b)
     'op_plus',  # operator+(a, b)
     'op_minus',  # operator-(a, b)
     'op_multiply',  # operator*(a, b)


### PR DESCRIPTION
関連 #67 , https://github.com/cpprefjp/site/issues/596

-----

こっちの repos に直接触れるのは初めてなので念の為 PR にしました。元 issue から意図通りの変更かなど確認の上、マージお願いします💁