### PR TITLE
Google Analyticsの新しい設定に対応

### DIFF
--- a/boostjp/templates/base.html
+++ b/boostjp/templates/base.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="ja" itemscope="" itemtype="http://schema.org/WebPage"> <!--<![endif]-->
     <head>
+        {% block analytics %}{% endblock %}
         <meta charset="UTF-8">
 
         <title>{% block title %}{% endblock %}</title>
@@ -241,7 +242,6 @@ function tree_onclick(e) {
     e.stopPropagation();
 }
         </script>
-    {% block analytics %}{% endblock %}
     </head>
     <body>
 <header>

--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html class="cpprefjp" lang="ja" itemscope="" itemtype="http://schema.org/WebPage">
     <head>
+        {% block analytics %}{% endblock %}
         <meta charset="UTF-8">
 
         <title>{% block title %}{% endblock %}</title>
@@ -48,7 +49,6 @@
   });
 </script>
 
-    {% block analytics %}{% endblock %}
     </head>
     <body>
 <header {% block header_attributes %}{% endblock %}>

--- a/settings/boostjp.py
+++ b/settings/boostjp.py
@@ -54,15 +54,13 @@ GOOGLE_SITE_SEARCH = '''
 
 # Google Analytics
 GOOGLE_ANALYTICS = '''
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-56896607-2"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-56896607-2', 'auto');
-  ga('send', 'pageview');
-
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-56896607-2');
 </script>
 '''
 

--- a/settings/cpprefjp.py
+++ b/settings/cpprefjp.py
@@ -54,14 +54,13 @@ GOOGLE_SITE_SEARCH = '''
 
 # Google Analytics
 GOOGLE_ANALYTICS = '''
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-56896607-1"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-56896607-1', 'auto');
-  ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-56896607-1');
 </script>
 '''
 


### PR DESCRIPTION
Google Analyticsの設定が変わるらしく、以下のような案内がでていました。

> グローバル サイトタグ（gtag.js）
> このプロパティで使用できる Global Site Tag（gtag.js）トラッキング コードです。このコードをコピーして、トラッキングするすべてのウェブページの `<HEAD>` 内の最初の要素として貼り付けてください。ページにすでに Global Site Tag が配置されている場合は、以下のスニペットの config 行のみを既存の Global Site Tag に追加してください。

(cpprefjp)

```
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=UA-56896607-1"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'UA-56896607-1');
</script>
```

(boostjp)

```
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=UA-56896607-2"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'UA-56896607-2');
</script>
```

対応してみましたが、これでどうでしょ。