### PR TITLE
内部リンクを相対リンクで生成する機能 with `settings.USE_RELATIVE_LINK = True`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 *.pyc
 cpprefjp/site/
 cpprefjp/cpprefjp.github.io/
+cpprefjp/cpprefjp.relative/
 boostjp/site/
 boostjp/boostjp.github.io/
+boostjp/boostjp.relative/
 settings.*.cache
 
 /crsearch.json/crsearch.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 *.pyc
 cpprefjp/site/
+cpprefjp/image/
 cpprefjp/cpprefjp.github.io/
 cpprefjp/cpprefjp.relative/
 boostjp/site/
+boostjp/image/
 boostjp/boostjp.github.io/
 boostjp/boostjp.relative/
 settings.*.cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ boostjp/boostjp.relative/
 settings.*.cache
 
 /crsearch.json/crsearch.json
+/crsearch.json/crsearch.js
 /cpprefjp/static/static/kunai
 /cpprefjp/static/static/crsearch/*
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ popd
 mkdir -p cpprefjp/static/static/crsearch
 pushd cpprefjp/static/static/crsearch
 ln -s ../../../../crsearch.json/crsearch.json crsearch.json
+ln -s ../../../../crsearch.json/crsearch.js crsearch.js # Optional (ローカル file:///... で閲覧する場合に必要)
 popd
 
 # site_generator 用の docker イメージを生成する

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ git submodule update -i
 
 ```bash
 git clone https://github.com/cpprefjp/site.git cpprefjp/site
+git clone https://github.com/cpprefjp/image.git cpprefjp/image
 
 # kunai 用のデータを生成する
 git clone https://github.com/cpprefjp/kunai.git
@@ -57,6 +58,7 @@ popd
 ```bash
 # この辺は必要に応じて実行する
 (cd cpprefjp/site && git pull)
+(cd cpprefjp/image && git pull)
 ./crsearch.json/docker.sh run
 ./kunai/docker.sh run build
 
@@ -75,6 +77,7 @@ http://localhost:8000 を開けば `index.html` が表示されます。
 
 ```bash
 git clone https://github.com/boostjp/site.git boostjp/site
+git clone https://github.com/boostjp/image.git boostjp/image
 
 # site_generator 用の docker イメージを生成する
 ./docker.sh build

--- a/boostjp/templates/base.html
+++ b/boostjp/templates/base.html
@@ -26,14 +26,14 @@
         {% block rss %}{% endblock %}
 
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-<link rel="stylesheet" href="/static/pygments/default.css">
-<!-- <link rel="stylesheet" href="/static/css/root.css"> -->
+<link rel="stylesheet" href="{{ relative_base }}/static/pygments/default.css">
+<!-- <link rel="stylesheet" href="{{ relative_base }}/static/css/root.css"> -->
 
 <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 <!-- <script src="//platform.twitter.com/widgets.js"></script> -->
 
-<!-- <script src="/static/js/root.js"></script> -->
+<!-- <script src="{{ relative_base }}/static/js/root.js"></script> -->
 
         {% block mathjax %}{% endblock %}
 
@@ -254,7 +254,7 @@ function tree_onclick(e) {
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="/">
+        <a class="navbar-brand" href="{{ relative_base }}/">
           <div class="title-wrapper clearfix">
             <div class="title">{% block brand %}{% endblock %}</div>
           </div>

--- a/boostjp/templates/base.html
+++ b/boostjp/templates/base.html
@@ -25,13 +25,13 @@
 
         {% block rss %}{% endblock %}
 
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 <link rel="stylesheet" href="{{ relative_base }}/static/pygments/default.css">
 <!-- <link rel="stylesheet" href="{{ relative_base }}/static/css/root.css"> -->
 
-<script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-<!-- <script src="//platform.twitter.com/widgets.js"></script> -->
+<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<!-- <script src="https://platform.twitter.com/widgets.js"></script> -->
 
 <!-- <script src="{{ relative_base }}/static/js/root.js"></script> -->
 
@@ -326,7 +326,7 @@ function tree_onclick(e) {
     </body>
     <!-- Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.  chromium.org/developers/how-tos/chrome-frame-getting-started -->
     <!--[if lt IE 7 ]>
-        <script src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>
         <script>
             window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})
         </script>

--- a/boostjp/templates/base.html
+++ b/boostjp/templates/base.html
@@ -254,7 +254,7 @@ function tree_onclick(e) {
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="{{ relative_base }}/">
+        <a class="navbar-brand" href="{{ relative_index }}">
           <div class="title-wrapper clearfix">
             <div class="title">{% block brand %}{% endblock %}</div>
           </div>

--- a/boostjp/templates/content.html
+++ b/boostjp/templates/content.html
@@ -15,7 +15,7 @@
       <li {{ 'style="display: none"' if not parent_opened }} class="parent_li {{ 'active' if child.opened }}">
         <span class="treespan" onclick="tree_onclick.call(this, event)"><i class="glyphicon {{ 'glyphicon-minus' if child.opened else 'glyphicon-plus' }}"></i></span>
         {% if child.href %}
-          <a href="{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
+          <a href="{{ relative_base }}{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
         {% else %}
           {{ child.title|e }}{{ child.encoded_cpp_meta }}
         {% endif %}
@@ -26,7 +26,7 @@
     {% else %}
       <li {{ 'style="display: none"' if not parent_opened }}>
         {% if child.href %}
-          <a href="{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
+          <a href="{{ relative_base }}{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
         {% else %}
           {{ child.title|e }}{{ child.encoded_cpp_meta }}
         {% endif %}
@@ -49,7 +49,7 @@
       <li {{ 'class="active"' if header.is_active }} itemscope itemtype="http://www.schema.org/SiteNavigationElement">
         <span>
           {% if not header.is_active and header.href %}
-            <a href="{{ header.href }}" itemprop="url">
+            <a href="{{ relative_base }}{{ header.href }}" itemprop="url">
               {% if loop.index == 1 %}
                 <i class="glyphicon glyphicon-home"></i>
               {% else %}

--- a/cpprefjp/ghwebhook_on_user.sh
+++ b/cpprefjp/ghwebhook_on_user.sh
@@ -60,6 +60,7 @@ cp crsearch.json/crsearch.json cpprefjp/static/static/crsearch/
 # サイト生成
 clone_and_fallback cpprefjp/cpprefjp.github.io git@github.com:cpprefjp/cpprefjp.github.io.git
 clone_and_fallback cpprefjp/site git@github.com:cpprefjp/site.git
+clone_and_fallback cpprefjp/image git@github.com:cpprefjp/image.git
 ./docker.sh build
 ./docker.sh run settings.cpprefjp "$@"
 

--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -24,7 +24,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{{ relative_base }}/static/favicons/apple-touch-icon.png{{ cachebust }}">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ relative_base }}/static/favicons/favicon-32x32.png{{ cachebust }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ relative_base }}/static/favicons/favicon-16x16.png{{ cachebust }}">
-<link rel="manifest" href="{{ relative_base }}/static/favicons/manifest.json{{ cachebust }}">
+<link rel="manifest" href="{{ relative_base }}/manifest.json{{ cachebust }}">
 <link rel="mask-icon" href="{{ relative_base }}/static/favicons/safari-pinned-tab.svg{{ cachebust }}" color="#f5f8fc">
 <meta name="theme-color" content="#f5f8fc">
 

--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -21,25 +21,25 @@
 
         {% block rss %}{% endblock %}
 
-<link rel="apple-touch-icon" sizes="180x180" href="/static/favicons/apple-touch-icon.png{{ cachebust }}">
-<link rel="icon" type="image/png" sizes="32x32" href="/static/favicons/favicon-32x32.png{{ cachebust }}">
-<link rel="icon" type="image/png" sizes="16x16" href="/static/favicons/favicon-16x16.png{{ cachebust }}">
-<link rel="manifest" href="/static/favicons/manifest.json{{ cachebust }}">
-<link rel="mask-icon" href="/static/favicons/safari-pinned-tab.svg{{ cachebust }}" color="#f5f8fc">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ relative_base }}/static/favicons/apple-touch-icon.png{{ cachebust }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ relative_base }}/static/favicons/favicon-32x32.png{{ cachebust }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ relative_base }}/static/favicons/favicon-16x16.png{{ cachebust }}">
+<link rel="manifest" href="{{ relative_base }}/static/favicons/manifest.json{{ cachebust }}">
+<link rel="mask-icon" href="{{ relative_base }}/static/favicons/safari-pinned-tab.svg{{ cachebust }}" color="#f5f8fc">
 <meta name="theme-color" content="#f5f8fc">
 
-<link rel="stylesheet" href="/static/pygments/default.css{{ cachebust }}">
-<!-- <link rel="stylesheet" href="/static/css/root.css"> -->
+<link rel="stylesheet" href="{{ relative_base }}/static/pygments/default.css{{ cachebust }}">
+<!-- <link rel="stylesheet" href="{{ relative_base }}/static/css/root.css"> -->
 
         {% block mathjax %}{% endblock %}
 
-<link href="/static/kunai/css/kunai-stage-0.css{{ cachebust }}" rel="stylesheet">
-<link href="/static/kunai/css/kunai-stage-1.css{{ cachebust }}" rel="stylesheet">
-<link href="/static/kunai/css/kunai-stage-2.css{{ cachebust }}" rel="stylesheet">
-<link href="/static/kunai/css/kunai-stage-3.css{{ cachebust }}" rel="stylesheet">
+<link href="{{ relative_base }}/static/kunai/css/kunai-stage-0.css{{ cachebust }}" rel="stylesheet">
+<link href="{{ relative_base }}/static/kunai/css/kunai-stage-1.css{{ cachebust }}" rel="stylesheet">
+<link href="{{ relative_base }}/static/kunai/css/kunai-stage-2.css{{ cachebust }}" rel="stylesheet">
+<link href="{{ relative_base }}/static/kunai/css/kunai-stage-3.css{{ cachebust }}" rel="stylesheet">
 
-<script type="text/javascript" src="/static/kunai/js/kunai-vendor.js{{ cachebust }}"></script>
-<script type="text/javascript" src="/static/kunai/js/kunai.js{{ cachebust }}"></script>
+<script type="text/javascript" src="{{ relative_base }}/static/kunai/js/kunai-vendor.js{{ cachebust }}"></script>
+<script type="text/javascript" src="{{ relative_base }}/static/kunai/js/kunai.js{{ cachebust }}"></script>
 
 <script type="text/javascript">
   document.addEventListener('DOMContentLoaded', function() {
@@ -61,7 +61,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="/">
+        <a class="navbar-brand" href="{{ relative_base }}/">
           <div class="title-wrapper clearfix">
             <div class="title">{% block brand %}{% endblock %}</div>
           </div>

--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -61,7 +61,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="{{ relative_base }}/">
+        <a class="navbar-brand" href="{{ relative_index }}">
           <div class="title-wrapper clearfix">
             <div class="title">{% block brand %}{% endblock %}</div>
           </div>

--- a/cpprefjp/templates/content.html
+++ b/cpprefjp/templates/content.html
@@ -17,7 +17,7 @@
       <li class="parent_li {{ 'active' if child.opened }}">
         <span class="treespan"></span>
         {% if child.href %}
-          <a href="{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
+          <a href="{{ relative_base }}{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
         {% else %}
           {{ child.title|e }}{{ child.encoded_cpp_meta }}
         {% endif %}
@@ -28,7 +28,7 @@
     {% else %}
       <li>
         {% if child.href %}
-          <a href="{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
+          <a href="{{ relative_base }}{{ child.href }}">{{ child.title|e }}</a>{{ child.encoded_cpp_meta }}
         {% else %}
           {{ child.title|e }}{{ child.encoded_cpp_meta }}
         {% endif %}
@@ -58,7 +58,7 @@
       <li {{ 'class="active"' if header.is_active }} itemscope itemtype="http://www.schema.org/SiteNavigationElement">
         <span>
           {% if not header.is_active and header.href %}
-            <a href="{{ header.href }}" itemprop="url">
+            <a href="{{ relative_base }}{{ header.href }}" itemprop="url">
               {% if loop.index == 1 %}
                 <i class="fa fa-fw fa-home"></i>
               {% else %}

--- a/crsearch.json/run.py
+++ b/crsearch.json/run.py
@@ -449,8 +449,11 @@ def main():
     paths = chain.from_iterable([get_files(d) for d in _KNOWN_DIRS])
     all_paths = list(get_files('site'))
     result = Generator().generate('site', paths, all_paths)
+    crsearch_json = json.dumps(result, separators=(',', ':'), ensure_ascii=False, sort_keys=True)
     with open('crsearch.json', 'wb') as f:
-        f.write(json.dumps(result, separators=(',', ':'), ensure_ascii=False, sort_keys=True).encode('utf-8'))
+        f.write(crsearch_json.encode('utf-8'))
+    with open('crsearch.js', 'wb') as f:
+        f.write(('callback(%s)' % crsearch_json).encode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/run.py
+++ b/run.py
@@ -71,6 +71,8 @@ def md_to_html(md_data, path, hrefs=None, global_qualify_list=None):
         'full_path': path + '.md',
         'extension': '.html',
         'use_relative_link': settings.USE_RELATIVE_LINK,
+        'image_repo': settings.IMAGE_REPO,
+        'use_static_image': settings.IMAGE_DIR is not None,
     }
     extension_configs['codehilite'] = {
         'noclasses': False
@@ -600,6 +602,13 @@ def main():
 
     # 静的ファイルをコピーする
     subprocess.call(['cp', '-v', '-RL'] + glob.glob(os.path.join(settings.STATIC_DIR, '*')) + [settings.OUTPUT_DIR])
+
+    # 画像リポジトリ (image) の画像ファイル (*.png, *.jpg, *.svg) をコピーする
+    if settings.IMAGE_DIR is not None:
+        os.system("cd '%s' && find . -name '*.png' -or -name '*.jpg' -or -name '*.svg' | tee /dev/stderr | cpio -updmv '%s'" % (
+            settings.IMAGE_DIR,
+            os.path.relpath(os.path.join(settings.OUTPUT_DIR, 'static/image'), settings.IMAGE_DIR)
+        ))
 
 
 if __name__ == '__main__':

--- a/run.py
+++ b/run.py
@@ -525,12 +525,15 @@ def convert_pageinfo(pageinfo, sidebar, sidebar_index, template, hrefs, global_q
         'project_name': settings.PROJECT_NAME,
         'latest_commit_info': latest_commit_info,
         'keywords': settings.META_KEYWORDS,
-        'relative_base': ''
+        'relative_base': '',
+        'relative_index': '/'
     }
     if settings.USE_RELATIVE_LINK:
         url_current_dir = posixpath.dirname(context['url'])
         context['relative_base'] = posixpath.relpath(settings.BASE_URL, url_current_dir)
-        # 以下は <meta /> で埋め込む情報なので敢えて相対パスにはしない。
+        # Note: ローカル (file:///) で閲覧時にディレクトリを開いてしまわないように "/" で終わらず "index.html"も明示する。
+        context['relative_index'] = posixpath.relpath(settings.BASE_URL, url_current_dir) + '/index.html'
+        # Note: 以下は <meta /> で埋め込む情報なので敢えて相対パスにはしない。
         # context['url'] = posixpath.relpath(context['url'], url_current_dir)
         # context['rss'] = posixpath.relpath(context['rss'], url_current_dir)
     convert(pageinfo['path'], template, context, hrefs, global_qualify_list)

--- a/settings/boostjp.py
+++ b/settings/boostjp.py
@@ -10,6 +10,10 @@ INPUT_DIR = 'boostjp/site'
 # 静的ファイルディレクトリ
 STATIC_DIR = 'boostjp/static'
 
+# 画像ファイルディレクトリ / GitHubリポジトリ
+IMAGE_DIR = 'boostjp/image'
+IMAGE_REPO = 'boostjp/image'
+
 # 出力ディレクトリ
 OUTPUT_DIR = 'boostjp/boostjp.github.io'
 

--- a/settings/boostjp.py
+++ b/settings/boostjp.py
@@ -81,6 +81,7 @@ META_KEYWORDS = 'C++,Boost,リファレンス,ドキュメント'
 # 'git' => CACHEBUST_DIR のディレクトリの git rev-parse HEAD の結果を使う
 CACHEBUST_TYPE = 'time'
 
+USE_RELATIVE_LINK = False
 
 # 並び替えルール
 def get_order_priority(name):

--- a/settings/boostjp_relative.py
+++ b/settings/boostjp_relative.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .boostjp import *  # NOQA
+
+USE_MINIFY = False
+
+OUTPUT_DIR = 'boostjp/boostjp.relative'
+GOOGLE_ANALYTICS = ''
+USE_RELATIVE_LINK = True

--- a/settings/cpprefjp.py
+++ b/settings/cpprefjp.py
@@ -10,6 +10,10 @@ INPUT_DIR = 'cpprefjp/site'
 # 静的ファイルディレクトリ
 STATIC_DIR = 'cpprefjp/static'
 
+# 画像ファイルディレクトリ / GitHubリポジトリ
+IMAGE_DIR = 'cpprefjp/image'
+IMAGE_REPO = 'cpprefjp/image'
+
 # 出力ディレクトリ
 OUTPUT_DIR = 'cpprefjp/cpprefjp.github.io'
 

--- a/settings/cpprefjp.py
+++ b/settings/cpprefjp.py
@@ -81,6 +81,8 @@ META_KEYWORDS = 'C++,標準ライブラリ,リファレンス,ドキュメント
 CACHEBUST_TYPE = 'git'
 CACHEBUST_DIR = 'kunai'
 
+USE_RELATIVE_LINK = False
+
 # 並び替えルール
 ORDER_PRIORITY_LIST = [
     'op_constructor',

--- a/settings/cpprefjp_relative.py
+++ b/settings/cpprefjp_relative.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .cpprefjp import *  # NOQA
+
+OUTPUT_DIR = 'cpprefjp/cpprefjp.relative'
+GOOGLE_ANALYTICS = ''
+USE_RELATIVE_LINK = True


### PR DESCRIPTION
https://github.com/cpprefjp/site/issues/917#issuecomment-967195045 で言及されたものです。現在 site_generator, markdown_to_html, crsearch, kunai に変更があります。

## 背景

現状では `site_generator` で生成されるコンテンツはトップレベル `/` に置かれるという想定でリンクが生成されています。このためローカルで閲覧しようとすると毎回新しいWebサーバーを立ち上げる必要が出てきます (特にリモートのマシン上で変換しているとファイヤーウォールやSELinuxやプロキシなどの設定もしなければならずとても面倒)。

内部のリンクを相対リンクにすればローカルで単にブラウザで開いて閲覧することができるので便利。また、単に設定済みの Web サーバーのサブディレクトリに配置すれば閲覧できるようになることを期待。未だ簡単なテストのみしかしていません。

## 変更 (2022-06-06 09:03 更新)

- site_generator - branch [`relative_link` ](https://github.com/akinomyoga/cpprefjp-site_generator/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-site_generator/compare/af559089d039d15395c8f426f66a5f1b5b984c0e...relative_link))
- markdown_to_html - branch [`relative_link`](https://github.com/akinomyoga/cpprefjp-markdown_to_html/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-markdown_to_html/compare/9c694ae4083fc57456bee0156cf283be393af1e4...relative_link))
- crsearch - branch [`relative_link`](https://github.com/akinomyoga/cpprefjp-crsearch/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-crsearch/compare/51ca714c6e8d9a3744150a2264ff5894c640f37e...relative_link))
- kunai - branch [`relative_link`](https://github.com/akinomyoga/cpprefjp-kunai/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-kunai/compare/852c507418230a4b02a31ea8b7a4e449aef1d941...relative_link))
- site - branch [`relative_link` ](https://github.com/akinomyoga/cpprefjp-site/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-site/compare/6809d28c7d5e094988cac60d9166391c3ce6af8f...relative_link))
- image - branch [`relative_link` ](https://github.com/akinomyoga/cpprefjp-image/tree/relative_link) ([diff](https://github.com/akinomyoga/cpprefjp-image/compare/d34326592cc6e059571cfd2a0628bf7e2c24dc93...relative_link))
- boostjp/site - branch [`relative_link` ](https://github.com/akinomyoga/boostjp-site/tree/relative_link) ([diff](https://github.com/akinomyoga/boostjp-site/compare/cf17e0dc5b9e326423d0df43744a55e8073f53c9...relative_link))
- boostjp/image - branch [`relative_link` ](https://github.com/akinomyoga/boostjp-image/tree/relative_link) ([diff](https://github.com/akinomyoga/boostjp-image/compare/d71646c37d61018d53d39bff2471e4f4197a2d98...relative_link))


## 現状の課題

### `navbar.css` の `background-image: url(.../cpprefjp-icon-v1.1-transparent.png)`

- [kunai/css/kunai/site/navbar.css#L51](https://github.com/akinomyoga/cpprefjp-kunai/blob/852c507418230a4b02a31ea8b7a4e449aef1d941/css/kunai/site/navbar.css#L51) から絶対URLで参照している cpprefjp アイコン (cpprefjp-icon-v1.1-transparent.png) をどうにかしたい。

→試しに相対リンクにしてみたら `./kunai/docker.sh run build` が失敗します。以下エラーメッセージです。どうしたら良いかすぐ分からず。現状の様に https://cpprefjp.github.io から直接取得していても (インターネットに繋がっている限りは) 取り敢えずは動く。

```
Entrypoint kunai-stage-3 = kunai-stage-3.js
runtime modules 0 bytes 3 modules
built modules 117 bytes (javascript) 404 KiB (unknown) [built]
  cacheable modules 117 bytes
    ./kunai-stage-0.css 39 bytes [built] [code generated]
    ./kunai-stage-2.scss 39 bytes [built] [code generated]
    ./kunai-stage-3.css 39 bytes [built] [code generated] [1 error]
  css modules 404 KiB
    css ../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!../node_modules/postcss-loader/src/index.js??ruleSet[1].rules[1].use[2]!./kunai-stage-0.css 1.89 KiB [built] [code generated]
    css ../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!../node_modules/postcss-loader/src/index.js??ruleSet[1].rules[0].use[2]!../node_modules/sass-loader/dist/cjs.js!./kunai-stage-2.scss 402 KiB [built] [code generated
]

ERROR in ./kunai-stage-3.css
Module build failed (from ../node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleNotFoundError: Module not found: Error: Can't resolve '../../original-icons/cpprefjp-icon-v1.1-transparent.png' in '/var/src/css'
    at /var/src/node_modules/webpack/lib/Compilation.js:2011:28
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:795:13
    at eval (eval at create (/var/src/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:8:1)
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:275:22
    at eval (eval at create (/var/src/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:7:1)
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:431:22
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:124:11
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:667:25
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:852:8
    at /var/src/node_modules/webpack/lib/NormalModuleFactory.js:972:5

1 ERROR in child compilations (Use 'stats.children: true' resp. '--stats-children' for more details)
webpack 5.64.4 compiled with 2 errors in 6073 ms
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! kunai@3.0.7 build: `rm -rf dist/ && webpack --config webpack.prod.js --mode production --env production && rm -f dist/kunai-stage-*.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the kunai@3.0.7 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-05-29T10_07_47_968Z-debug.log
```

### 追記: ローカルで閲覧しようとすると crsearch.json の読み込みで CORS (Cross-origin resource sharing) エラー

> Access to XMLHttpRequest at 'file:///.../static/crsearch/crsearch.json' from origin 'null' has been blocked by CORS policy: Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, chrome-untrusted, https.

結局Webサーバーは必要になってしまう? `https://cpprefjp.github.io/static/crsearch/crsearch.json` を読ませれば動くが…。

→現状は取り敢えず、ローカルで動いているとき (file:///.... のとき) は https://cpprefjp.github.io/ から crsearch.json を取得するようにしています ([852c5074 @ kunai](https://github.com/akinomyoga/cpprefjp-kunai/commit/4cd391719b8a345caed511fc942e52b54b17561f#diff-36d7606a801e48c300035d4f84af2d663224b0ca91789d0123da4cab6395c13bR138-R151))。

根本的に解決するためには XHR ではなく `<script>` で取得 (JSONP) するなど???

### 追記: `crsearch.json/run.py` にハードコードされている `base_url` を何とかする

https://github.com/cpprefjp/site_generator/blob/af559089d039d15395c8f426f66a5f1b5b984c0e/crsearch.json/run.py#L429

そもそも `crsearch.json` に `base_url` を格納する必要性はあるのだろうか?

→相対リンクにするとそもそも `base_url` はファイルによって `.` だったり `..` だったり `../..` だったりで動的に変わるので、`crsearch.json` に含めても仕方がない。CRSearch の初期化オプションで base_url を動的に指定できるようにすることにしています ([d1eb6a47 @ crsearch](https://github.com/akinomyoga/cpprefjp-crsearch/commit/d1eb6a47f81ef6278470f470da2713f949f5b100), [852c5074 @ kunai](https://github.com/akinomyoga/cpprefjp-kunai/commit/4cd391719b8a345caed511fc942e52b54b17561f#diff-36d7606a801e48c300035d4f84af2d663224b0ca91789d0123da4cab6395c13bR167))。

### 追記: raw.githubusercontent.com/cpprefjp/image にあるデータもサイトの中に含めるべきでは

そうでないとオフラインで閉じて閲覧できるようにはならない。


