### PR TITLE
MathJaxのブロック数式 : 左に詰まっていたのでインデントをつけた

### DIFF
--- a/boostjp/templates/content.html
+++ b/boostjp/templates/content.html
@@ -106,19 +106,20 @@
 
 {% block mathjax %}
   {% if mathjax %}
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        extensions: ["tex2jax.js"],
-        jax: ["input/TeX", "output/HTML-CSS"],
-        tex2jax: {
-          inlineMath: [ ['$','$'] ],
-          displayMath: [ ['$$','$$'] ],
-          processEscapes: true
-        },
-        "HTML-CSS": { availableFonts: ["TeX"] },
-        displayAlign: "left",
-      });
+    <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [ ['$','$'] ],
+        displayMath: [ ['$$','$$'] ],
+        processEscapes: true
+      },
+      chtml: {
+        displayAlign: 'left',
+        displayIndent: '2.0em',
+      },
+    };
     </script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   {% endif %}
 {% endblock %}

--- a/cpprefjp/templates/content.html
+++ b/cpprefjp/templates/content.html
@@ -116,19 +116,20 @@
 
 {% block mathjax %}
   {% if mathjax %}
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        extensions: ["tex2jax.js"],
-        jax: ["input/TeX", "output/HTML-CSS"],
-        tex2jax: {
-          inlineMath: [ ['$','$'] ],
-          displayMath: [ ['$$','$$'] ],
-          processEscapes: true
-        },
-        "HTML-CSS": { availableFonts: ["TeX"] },
-        displayAlign: "left",
-      });
+    <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [ ['$','$'] ],
+        displayMath: [ ['$$','$$'] ],
+        processEscapes: true
+      },
+      chtml: {
+        displayAlign: 'left',
+        displayIndent: '2.0em',
+      },
+    };
     </script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
- https://github.com/cpprefjp/site/issues/1284
- [Upgrading from v2 to v3 - MathJax](https://docs.mathjax.org/en/latest/upgrading/v2.html)

MathJaxがメジャーバージョンアップしてConfigの書き方が変わっていたので、バージョンアップして書き方も直しました。

![スクリーンショット 2024-05-26 13 26 13](https://github.com/cpprefjp/site_generator/assets/240038/477dc36d-75a1-4202-9321-2e3af9586be3)