### PR TITLE
`markdown_to_html` 更新 (`html_attribute` 修正)

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -3,6 +3,10 @@ flake8-import-order==0.18.1
 hacking==2.0.0
 htmlmin==0.1.12
 Jinja2==3.0.3
+# markdown_to_html/html_attribute.py が HTML 実体参照の処理のために Markdown の
+# 内部実装に依存しているので、Markdown バージョンを更新するときは動作確認が必要。
+# 詳細については html_attribute.py の _tohtml(element) のコードコメントを参照の
+# こと
 Markdown==3.2.1
 Pygments==2.5.2
 regex==2020.2.20


### PR DESCRIPTION
https://github.com/cpprefjp/markdown_to_html/pull/7 と呼応する修正です。

----

https://github.com/cpprefjp/markdown_to_html/pull/7#issuecomment-2487693686 で言及されていたコメントについて。

> なるほど、markdownライブラリの最新3.7 (現在使ってるのは3.2.1) でも直ってないことは確認しました。markdownライブラリをハックして使うならこうせざるを得ない感じはしますね。
> 
> バージョン固定はしてあるので、将来バージョンアップするときのためにコメントを残しておけばよいように思います

どうやら `requirements.txt` に `#` でコメントを記入できるようなので、バージョンを変更する時に見落とさないようにそこにコメントを入れてみました。ただし、本当にコメントを入れてもちゃんと動くかどうか試していません。
