### PR TITLE
cpprefjp/robots.txt: Disallow `/site/gen/`

### DIFF
--- a/cpprefjp/static/robots.txt
+++ b/cpprefjp/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Disallow: /site/gen/
 Sitemap: http://cpprefjp.github.io/sitemap.xml


### PR DESCRIPTION
https://github.com/cpprefjp/site/pull/1401 にて自動生成されたプレビュー を、検索エンジンのインデックスの対象外とするための修正です。