### PR TITLE
cpprefjp のフッターのライセンスの説明を更新

### DIFF
--- a/cpprefjp/templates/base.html
+++ b/cpprefjp/templates/base.html
@@ -122,7 +122,7 @@
   <div class="container-fluid">
     <p><small>
       本サイトの情報は、
-        <a href="https://creativecommons.org/licenses/by/3.0/deed.ja" rel="nofollow">クリエイティブ・コモンズ 表示 3.0 非移植 ライセンス(CC BY)</a>
+        <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" rel="nofollow">クリエイティブ・コモンズ 表示 4.0 非移植 ライセンス(CC BY)</a>
       の下に提供されています。
     </small></p>
   </div>


### PR DESCRIPTION
cpprefjp のライセンスのバージョン更新 (https://github.com/cpprefjp/site/pull/1459) に合わせて、 cpprefjp のフッターの説明を修正しました。