### PR TITLE
C++20までのシンタックスハイライトに対応

### DIFF
--- a/boostjp/static/static/pygments/default.css
+++ b/boostjp/static/static/pygments/default.css
@@ -4,12 +4,15 @@ pre .c { color: #60a0b0; } /* Comment */
 pre .err { border: 1px solid #FF0000 } /* Error */
 pre .k { color: #007020; font-weight: bold } /* Keyword */
 pre .o { color: #666666 } /* Operator */
+pre .ch { color: #60a0b0; } /* Comment.Hashbang */
 pre .cm { color: #60a0b0; } /* Comment.Multiline */
 pre .cp { color: #007020 } /* Comment.Preproc */
+pre .cpf { color: #60a0b0; } /* Comment.PreprocFile */
 pre .c1 { color: #60a0b0; } /* Comment.Single */
 pre .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
 pre .gd { color: #A00000 } /* Generic.Deleted */
 pre .ge { } /* Generic.Emph */
+pre .ges { font-weight: bold } /* Generic.EmphStrong */
 pre .gr { color: #FF0000 } /* Generic.Error */
 pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
 pre .gi { color: #00A000 } /* Generic.Inserted */
@@ -34,6 +37,7 @@ pre .nd { color: #555555; font-weight: bold } /* Name.Decorator */
 pre .ni { color: #d55537; font-weight: bold } /* Name.Entity */
 pre .ne { color: #007020 } /* Name.Exception */
 pre .nf { color: #06287e } /* Name.Function */
+pre .fm { color: #06287e } /* Name.Function.Magic */
 pre .nl { color: #002070; font-weight: bold } /* Name.Label */
 pre .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
 pre .nt { color: #062873; font-weight: bold } /* Name.Tag */
@@ -45,8 +49,10 @@ pre .mf { color: #40a070 } /* Literal.Number.Float */
 pre .mh { color: #40a070 } /* Literal.Number.Hex */
 pre .mi { color: #40a070 } /* Literal.Number.Integer */
 pre .mo { color: #40a070 } /* Literal.Number.Oct */
+pre .sa { color: #4070a0 } /* Literal.String.Affix */
 pre .sb { color: #4070a0 } /* Literal.String.Backtick */
 pre .sc { color: #4070a0 } /* Literal.String.Char */
+pre .dl { color: #4070a0 } /* Literal.String.Delimiter */
 pre .sd { color: #4070a0; } /* Literal.String.Doc */
 pre .s2 { color: #4070a0 } /* Literal.String.Double */
 pre .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
@@ -60,18 +66,22 @@ pre .bp { color: #007020 } /* Name.Builtin.Pseudo */
 pre .vc { color: #bb60d5 } /* Name.Variable.Class */
 pre .vg { color: #bb60d5 } /* Name.Variable.Global */
 pre .vi { color: #bb60d5 } /* Name.Variable.Instance */
+pre .vm { color: #bb60d5 } /* Name.Variable.Magic */
 pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { background-color: #ffffcc }
 .syntax pre  { background: #f8f8f8; }
 .syntax pre .c { color: #408080; } /* Comment */
 .syntax pre .err { border: 1px solid #FF0000 } /* Error */
 .syntax pre .k { color: #008000; font-weight: bold } /* Keyword */
 .syntax pre .o { color: #666666 } /* Operator */
+.syntax pre .ch { color: #408080; } /* Comment.Hashbang */
 .syntax pre .cm { color: #408080; } /* Comment.Multiline */
 .syntax pre .cp { color: #BC7A00 } /* Comment.Preproc */
+.syntax pre .cpf { color: #408080; } /* Comment.PreprocFile */
 .syntax pre .c1 { color: #408080; } /* Comment.Single */
 .syntax pre .cs { color: #408080; } /* Comment.Special */
 .syntax pre .gd { color: #A00000 } /* Generic.Deleted */
 .syntax pre .ge { } /* Generic.Emph */
+.syntax pre .ges { font-weight: bold } /* Generic.EmphStrong */
 .syntax pre .gr { color: #FF0000 } /* Generic.Error */
 .syntax pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
 .syntax pre .gi { color: #00A000 } /* Generic.Inserted */
@@ -96,6 +106,7 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .ni { color: #999999; font-weight: bold } /* Name.Entity */
 .syntax pre .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
 .syntax pre .nf { color: #0000FF } /* Name.Function */
+.syntax pre .fm { color: #0000FF } /* Name.Function.Magic */
 .syntax pre .nl { color: #A0A000 } /* Name.Label */
 .syntax pre .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
 .syntax pre .nt { color: #008000; font-weight: bold } /* Name.Tag */
@@ -107,8 +118,10 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .mh { color: #666666 } /* Literal.Number.Hex */
 .syntax pre .mi { color: #666666 } /* Literal.Number.Integer */
 .syntax pre .mo { color: #666666 } /* Literal.Number.Oct */
+.syntax pre .sa { color: #BA2121 } /* Literal.String.Affix */
 .syntax pre .sb { color: #BA2121 } /* Literal.String.Backtick */
 .syntax pre .sc { color: #BA2121 } /* Literal.String.Char */
+.syntax pre .dl { color: #BA2121 } /* Literal.String.Delimiter */
 .syntax pre .sd { color: #BA2121; } /* Literal.String.Doc */
 .syntax pre .s2 { color: #BA2121 } /* Literal.String.Double */
 .syntax pre .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
@@ -122,4 +135,5 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .vc { color: #19177C } /* Name.Variable.Class */
 .syntax pre .vg { color: #19177C } /* Name.Variable.Global */
 .syntax pre .vi { color: #19177C } /* Name.Variable.Instance */
+.syntax pre .vm { color: #19177C } /* Name.Variable.Magic */
 .syntax pre .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/cpprefjp/static/static/pygments/default.css
+++ b/cpprefjp/static/static/pygments/default.css
@@ -4,12 +4,15 @@ pre .c { color: #60a0b0; } /* Comment */
 pre .err { border: 1px solid #FF0000 } /* Error */
 pre .k { color: #007020; font-weight: bold } /* Keyword */
 pre .o { color: #666666 } /* Operator */
+pre .ch { color: #60a0b0; } /* Comment.Hashbang */
 pre .cm { color: #60a0b0; } /* Comment.Multiline */
 pre .cp { color: #007020 } /* Comment.Preproc */
+pre .cpf { color: #60a0b0; } /* Comment.PreprocFile */
 pre .c1 { color: #60a0b0; } /* Comment.Single */
 pre .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
 pre .gd { color: #A00000 } /* Generic.Deleted */
 pre .ge { } /* Generic.Emph */
+pre .ges { font-weight: bold } /* Generic.EmphStrong */
 pre .gr { color: #FF0000 } /* Generic.Error */
 pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
 pre .gi { color: #00A000 } /* Generic.Inserted */
@@ -34,6 +37,7 @@ pre .nd { color: #555555; font-weight: bold } /* Name.Decorator */
 pre .ni { color: #d55537; font-weight: bold } /* Name.Entity */
 pre .ne { color: #007020 } /* Name.Exception */
 pre .nf { color: #06287e } /* Name.Function */
+pre .fm { color: #06287e } /* Name.Function.Magic */
 pre .nl { color: #002070; font-weight: bold } /* Name.Label */
 pre .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
 pre .nt { color: #062873; font-weight: bold } /* Name.Tag */
@@ -45,8 +49,10 @@ pre .mf { color: #40a070 } /* Literal.Number.Float */
 pre .mh { color: #40a070 } /* Literal.Number.Hex */
 pre .mi { color: #40a070 } /* Literal.Number.Integer */
 pre .mo { color: #40a070 } /* Literal.Number.Oct */
+pre .sa { color: #4070a0 } /* Literal.String.Affix */
 pre .sb { color: #4070a0 } /* Literal.String.Backtick */
 pre .sc { color: #4070a0 } /* Literal.String.Char */
+pre .dl { color: #4070a0 } /* Literal.String.Delimiter */
 pre .sd { color: #4070a0; } /* Literal.String.Doc */
 pre .s2 { color: #4070a0 } /* Literal.String.Double */
 pre .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
@@ -60,18 +66,22 @@ pre .bp { color: #007020 } /* Name.Builtin.Pseudo */
 pre .vc { color: #bb60d5 } /* Name.Variable.Class */
 pre .vg { color: #bb60d5 } /* Name.Variable.Global */
 pre .vi { color: #bb60d5 } /* Name.Variable.Instance */
+pre .vm { color: #bb60d5 } /* Name.Variable.Magic */
 pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { background-color: #ffffcc }
 .syntax pre  { background: #f8f8f8; }
 .syntax pre .c { color: #408080; } /* Comment */
 .syntax pre .err { border: 1px solid #FF0000 } /* Error */
 .syntax pre .k { color: #008000; font-weight: bold } /* Keyword */
 .syntax pre .o { color: #666666 } /* Operator */
+.syntax pre .ch { color: #408080; } /* Comment.Hashbang */
 .syntax pre .cm { color: #408080; } /* Comment.Multiline */
 .syntax pre .cp { color: #BC7A00 } /* Comment.Preproc */
+.syntax pre .cpf { color: #408080; } /* Comment.PreprocFile */
 .syntax pre .c1 { color: #408080; } /* Comment.Single */
 .syntax pre .cs { color: #408080; } /* Comment.Special */
 .syntax pre .gd { color: #A00000 } /* Generic.Deleted */
 .syntax pre .ge { } /* Generic.Emph */
+.syntax pre .ges { font-weight: bold } /* Generic.EmphStrong */
 .syntax pre .gr { color: #FF0000 } /* Generic.Error */
 .syntax pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
 .syntax pre .gi { color: #00A000 } /* Generic.Inserted */
@@ -96,6 +106,7 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .ni { color: #999999; font-weight: bold } /* Name.Entity */
 .syntax pre .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
 .syntax pre .nf { color: #0000FF } /* Name.Function */
+.syntax pre .fm { color: #0000FF } /* Name.Function.Magic */
 .syntax pre .nl { color: #A0A000 } /* Name.Label */
 .syntax pre .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
 .syntax pre .nt { color: #008000; font-weight: bold } /* Name.Tag */
@@ -107,8 +118,10 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .mh { color: #666666 } /* Literal.Number.Hex */
 .syntax pre .mi { color: #666666 } /* Literal.Number.Integer */
 .syntax pre .mo { color: #666666 } /* Literal.Number.Oct */
+.syntax pre .sa { color: #BA2121 } /* Literal.String.Affix */
 .syntax pre .sb { color: #BA2121 } /* Literal.String.Backtick */
 .syntax pre .sc { color: #BA2121 } /* Literal.String.Char */
+.syntax pre .dl { color: #BA2121 } /* Literal.String.Delimiter */
 .syntax pre .sd { color: #BA2121; } /* Literal.String.Doc */
 .syntax pre .s2 { color: #BA2121 } /* Literal.String.Double */
 .syntax pre .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
@@ -122,4 +135,5 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
 .syntax pre .vc { color: #19177C } /* Name.Variable.Class */
 .syntax pre .vg { color: #19177C } /* Name.Variable.Global */
 .syntax pre .vi { color: #19177C } /* Name.Variable.Instance */
+.syntax pre .vm { color: #19177C } /* Name.Variable.Magic */
 .syntax pre .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,5 +8,5 @@ Jinja2==3.0.3
 # 詳細については html_attribute.py の _tohtml(element) のコードコメントを参照の
 # こと
 Markdown==3.2.1
-Pygments==2.5.2
+Pygments==2.19.2
 regex==2020.2.20


### PR DESCRIPTION
依存ライブラリのPygmentsを更新し、C++20までのシンタックスハイライトに対応しました。
個別ページなどで指定したコード修飾が優先されるので、コルーチンページのようにco_yieldを赤文字で表示しているようなものは、そのままになります。

https://cpprefjp.github.io/lang/cpp20/coroutines.html

どなたか動作確認をお願いしたいです。